### PR TITLE
added capability to use driver-built selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.12.0]
+- :rocket: added capability to use driver-built selector
+```javascript
+const { NativeSelector } = require('@qavajs/po-playwright');
+
+class App {
+    Element = $(NativeSelector(page => page.getByText(`some text`)));
+}
+```
+
 ## [0.11.3]
 - :beetle: fixed logging Selector functions
 

--- a/README.MD
+++ b/README.MD
@@ -108,3 +108,16 @@ Then you can pass parameter to this function from Gherkin file
 ```gherkin
 When I click 'Component > Element (2)'
 ```
+
+## Native framework selectors
+It is also possible to use driver-built capabilities to return element. You can pass handler that has access to
+current `page` object. 
+
+```javascript
+const { NativeSelector } = require('@qavajs/po-playwright');
+
+class Component {
+    selector = '.container';
+    Element = $(NativeSelector(page => page.getByText(`some text`))); 
+}
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ declare class Component {
     constructor(selector?: any)
 }
 declare function Selector(selectorFunction: Function): any
+declare function NativeSelector(selectorFunction: Function): any
 declare module '@qavajs/po-playwright' {
-    export { $, $$, po, Component, Selector }
+    export { $, $$, po, Component, Selector, NativeSelector }
 }

--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 const po = require('./lib/PO').default;
 const { $, $$ } = require('./lib/register');
 const { Component } = require('./lib/Component');
-const { Selector } = require('./lib/Selector');
+const { Selector, NativeSelector } = require('./lib/Selector');
 
 module.exports = {
     po,
     $,
     $$,
     Component,
-    Selector
+    Selector,
+    NativeSelector
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@qavajs/po-playwright",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qavajs/po-playwright",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^0.34.6",
-        "playwright": "^1.39.0",
+        "playwright": "^1.40.0",
         "typescript": "^5.2.2",
         "vitest": "^0.34.6"
       }
@@ -1055,12 +1055,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
+      "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.39.0"
+        "playwright-core": "1.40.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1073,9 +1073,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
+      "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -2148,19 +2148,19 @@
       }
     },
     "playwright": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
+      "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.39.0"
+        "playwright-core": "1.40.0"
       }
     },
     "playwright-core": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
+      "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
       "dev": true
     },
     "postcss": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qavajs/po-playwright",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "library for plain-english access to page object",
   "main": "index.js",
   "scripts": {
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "@vitest/coverage-v8": "^0.34.6",
-    "playwright": "^1.39.0",
+    "playwright": "^1.40.0",
     "typescript": "^5.2.2",
     "vitest": "^0.34.6"
   }

--- a/src/Selector.ts
+++ b/src/Selector.ts
@@ -1,8 +1,15 @@
-export function Selector(selectorFunction: Function) {
+import { Locator, Page } from 'playwright';
 
+export function NativeSelector(selectorFunction: (page: Page) => Locator) {
+    return {
+        isNativeSelector: true,
+        selectorFunction
+    }
+}
+
+export function Selector(selectorFunction: Function) {
     return {
         isSelectorFunction: true,
         selectorFunction
     }
-
 }

--- a/src/register.ts
+++ b/src/register.ts
@@ -4,7 +4,11 @@ export interface DefinitionOptions {
 export interface Definition {
     selector: any;
     isCollection: boolean;
-    ignoreHierarchy: boolean
+    ignoreHierarchy: boolean;
+    isSelectorFunction?: boolean;
+    isNativeSelector?: boolean;
+    selectorFunction?: Function;
+    resolvedSelector?: any;
 }
 
 /**

--- a/tests/import.spec.ts
+++ b/tests/import.spec.ts
@@ -1,5 +1,5 @@
 import {test, expect} from 'vitest';
-import {po, $, $$, Component} from '../index';
+import {po, $, $$, Component, Selector, NativeSelector} from '../index';
 
 test('po', () => {
     expect(po.init).toBeInstanceOf(Function);
@@ -16,4 +16,12 @@ test('$$', () => {
 
 test('Component', () => {
     expect(Component).toBeInstanceOf(Function);
+});
+
+test('Selector', () => {
+    expect(Selector).toBeInstanceOf(Function);
+});
+
+test('NativeSelector', () => {
+    expect(NativeSelector).toBeInstanceOf(Function);
 });

--- a/tests/po.spec.ts
+++ b/tests/po.spec.ts
@@ -164,6 +164,16 @@ test('get collection by parametrised selector', async () => {
     expect(await element.count()).toEqual(3);
 });
 
+test('get native single element', async () => {
+    const element = await po.getElement('Native Selector Single Element');
+    expect(await element.innerText()).toBe('text of single element');
+});
+
+test('get native collection', async () => {
+    const collection = await po.getElement('Native Selector List');
+    expect(await collection.count()).toBe(6);
+});
+
 afterAll(async () => {
     await browser.close();
-})
+});

--- a/tests/samplePO.ts
+++ b/tests/samplePO.ts
@@ -1,6 +1,6 @@
 import { $, $$ } from '../src/register';
 import { Component } from '../src/Component';
-import { Selector } from '../src/Selector';
+import { Selector, NativeSelector } from '../src/Selector';
 
 class MultipleComponent extends Component {
     ChildItem = $('div');
@@ -54,6 +54,8 @@ class App {
     NotExistingComponent = $(new NotExistingComponent());
     ComponentWithoutSelector = $(new ComponentWithoutSelector());
     ComponentsWithoutSelector = $$(new ComponentWithoutSelector());
+    NativeSelectorSingleElement = $(NativeSelector(page => page.locator('.single-element')));
+    NativeSelectorList = $$(NativeSelector(page => page.locator('.list li')));
 }
 
 export default new App();


### PR DESCRIPTION
example of usage

```javascript
const { NativeSelector } = require('@qavajs/po-playwright');

class App {
    Element = $(NativeSelector(page => page.getByText(`some text`)));
}
```